### PR TITLE
requirements.txt updated

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 asgiref==3.7.2
-backports.zoneinfo==0.2.1
+backports.zoneinfo==0.2.1;python_version<"3.9"
 Django==4.2.5
 djangorestframework==3.14.0
 pytz==2023.3.post1


### PR DESCRIPTION
We don't have to install `backports.zoneinfo` when using python >= 3.9, and it is also giving errors.